### PR TITLE
Add custom hooks for state management and debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "firebase": "^11.4.0",
         "framer-motion": "^12.5.0",
         "gh-pages": "^6.3.0",
-        "lodash": "^4.17.21",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "firebase": "^11.4.0",
     "framer-motion": "^12.5.0",
     "gh-pages": "^6.3.0",
-    "lodash": "^4.17.21",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import CustomNavBar from './components/CustomNavBar'
 import Auth from './screens/Auth'
 import Error404 from './screens/Error404'
 import { ScreenContextProvider } from './contexts/ScreenContext'
-import { use, useEffect, useRef } from 'react'
+import { use, useRef } from 'react'
 import { UserContext } from './contexts/UserContext'
 import { AnimatePresence, motion } from 'framer-motion'
 import Dashboard from './screens/Dashboard'
@@ -17,10 +17,6 @@ function App() {
   const { user } = use(UserContext)
   const location = useLocation()
   const scrollContainerRef = useRef(null)
-
-  useEffect(() => {
-    console.log(user)
-  }, [user])
 
   return (
     <AnimatePresence mode='wait'>

--- a/src/hooks/useConsoleLog.jsx
+++ b/src/hooks/useConsoleLog.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+/**
+ * Custom hook to log a value to the console whenever it changes.
+ *
+ * @param {string} label - The label of the logged value.
+ * @param {any} value - The value to log to the console.
+ * 
+ * @example
+ * useConsoleLog('Name', name)
+ * 
+ * @example
+ * useConsoleLog('Count', count)
+ */
+const useConsoleLog = (label, value) => {
+  useEffect(() => {
+    if (value === undefined) {
+      console.log(`${label}: %c${value}`, 'color: navy; font-weight: bold;')
+    } else if (value === null) {
+      console.log(`${label}: %c${value}`, 'color: red; font-weight: bold;')
+    } else {
+      console.log(label, value)
+    }
+  }, [label, value])
+}
+
+export default useConsoleLog

--- a/src/hooks/useDebounce.jsx
+++ b/src/hooks/useDebounce.jsx
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Custom hook to debounce a callback function.
+ *
+ * @param {Function} callback - The function to debounce.
+ * @param {number} delay - The delay in milliseconds before executing the function.
+ * @param {Array} [dependencies] - Optional dependencies that will trigger the callback immediately.
+ * @returns {Function} - A debounced version of the callback function.
+ *
+ * @example
+ * const debouncedSearch = useDebounce((query) => fetchResults(query), 500, [searchQuery]);
+ */
+const useDebounce = (callback, delay, dependencies = null) => {
+  const timeoutRef = useRef(null)
+  const callbackRef = useRef(callback)
+
+  // Update the latest callback function to prevent stale closures
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  // Debounced function
+  const debouncedFunction = useCallback(
+    (...args) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current(...args)
+      }, delay)
+    },
+    [delay] // Only change when `delay` updates
+  )
+
+  // If dependencies are provided, execute callback when they change
+  useEffect(() => {
+    if (dependencies !== null) {
+      callbackRef.current()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies ?? [])
+
+  return debouncedFunction
+}
+
+export default useDebounce

--- a/src/hooks/useLocalStorage.jsx
+++ b/src/hooks/useLocalStorage.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+const getSavedValue = (key, initialValue) => {
+  const savedValue = JSON.parse(localStorage.getItem(key))
+  if (savedValue) return savedValue
+
+  if (initialValue instanceof Function) return initialValue()
+  return initialValue
+}
+
+/**
+ * Custom hook to manage state with localStorage.
+ *
+ * @param {string} key - The key under which the value is stored in localStorage.
+ * @param {any} initialValue - The initial value to use if there is no saved value.
+ * @returns {[any, Function]} - An array containing the current value and a function to update it.
+ * 
+ * @example
+ * const [name, setName] = useLocalStorage('name', 'John Doe')
+ * 
+ * @example
+ * const [count, setCount] = useLocalStorage('count', 0)
+ */
+const useLocalStorage = (key, initialValue) => {
+  const [value, setValue] = useState(() => {
+    return getSavedValue(key, initialValue)
+  })
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value))
+  }, [key, value])
+
+  return [value, setValue]
+}
+
+export default useLocalStorage

--- a/src/hooks/useStopWatch.jsx
+++ b/src/hooks/useStopWatch.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect, useRef } from 'react'
+
+/**
+ * Custom hook to manage a stopwatch.
+ *
+ * @param {boolean} autoStart - Whether the stopwatch should start automatically.
+ * @param {number | Date | { seconds: number, nanoseconds: number }} initialTime - The initial time of the stopwatch. Can be a number (seconds), a Date object, or a Firebase timestamp.
+ * @returns {Object} - An object containing the current time in seconds, running state, and control functions.
+ * @returns {number} time - The current time of the stopwatch in seconds.
+ * @returns {boolean} isRunning - The running state of the stopwatch.
+ * @returns {Function} start - Function to start the stopwatch.
+ * @returns {Function} stop - Function to stop the stopwatch.
+ * @returns {Function} reset - Function to reset the stopwatch.
+ * 
+ * @example
+ * const { time, isRunning, start, stop, reset } = useStopWatch(false, new Date())
+ */
+const useStopWatch = (autoStart = false, initialTime = 0) => {
+  const parseInitialTime = (time) => {
+    if (time instanceof Date) {
+      return Math.floor(time.getTime() / 1000)
+    } else if (typeof time === 'object' && time.seconds !== undefined && time.nanoseconds !== undefined) {
+      return time.seconds
+    } else if (typeof time === 'number') {
+      return time
+    } else {
+      return 0
+    }
+  }
+
+  const [time, setTime] = useState(parseInitialTime(initialTime))
+  const [isRunning, setIsRunning] = useState(autoStart)
+  const intervalRef = useRef(null)
+
+  useEffect(() => {
+    if (isRunning) {
+      const startTime = Date.now() - time * 1000
+      intervalRef.current = setInterval(() => {
+        setTime(Math.floor((Date.now() - startTime) / 1000))
+      }, 1000)
+    } else if (!isRunning && intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+
+    return () => clearInterval(intervalRef.current)
+  }, [isRunning, time])
+
+  const start = () => setIsRunning(true)
+  const stop = () => setIsRunning(false)
+  const reset = () => {
+    setTime(parseInitialTime(initialTime))
+    setIsRunning(false)
+  }
+
+  return {
+    time,
+    isRunning,
+    start,
+    stop,
+    reset,
+  }
+}
+
+export default useStopWatch

--- a/src/hooks/useTimeout.jsx
+++ b/src/hooks/useTimeout.jsx
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Custom hook to manage a timeout.
+ *
+ * @param {Function} callback - The callback function to be executed after the delay.
+ * @param {number} delay - The delay in milliseconds before the callback is executed.
+ * @returns {Object} - An object containing the reset and clear functions.
+ * @returns {Function} reset - Function to reset the timeout.
+ * @returns {Function} clear - Function to clear the timeout.
+ * 
+ * @example
+ * const { reset, clear } = useTimeout(() => {
+ *   console.log('Timeout executed')
+ * }, 1000)
+ */
+const useTimeout = (callback, delay) => {
+  const callbackRef = useRef(callback)
+  const timeoutRef = useRef()
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  const set = useCallback(() => {
+    timeoutRef.current = setTimeout(() => callbackRef.current(), delay)
+  }, [delay])
+
+  const clear = useCallback(() => {
+    timeoutRef.current && clearTimeout(timeoutRef.current)
+  }, [])
+
+  useEffect(() => {
+    set()
+    return clear
+  }, [delay, set, clear])
+
+  const reset = useCallback(() => {
+    clear()
+    set()
+  }, [clear, set])
+
+  return { reset, clear }
+}
+
+export default useTimeout

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { use } from 'react'
+import { use } from 'react'
 import { ScreenContext } from '../contexts/ScreenContext'
 
 const Dashboard = () => {

--- a/src/screens/MainLoading.jsx
+++ b/src/screens/MainLoading.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 const MainLoading = () => {
   return (


### PR DESCRIPTION
Introduce several custom hooks: `useLocalStorage` for state persistence, `useConsoleLog` for value logging, `useStopWatch` for timing operations, and `useDebounce` for debouncing functions. Remove the lodash library as its functionality is now covered by the new hooks. Optimize the usage of debounce in the screen context.